### PR TITLE
Changes PostgreSQLDatabaseAdapter for julia 1.0

### DIFF
--- a/src/database_adapters/PostgreSQLDatabaseAdapter.jl
+++ b/src/database_adapters/PostgreSQLDatabaseAdapter.jl
@@ -257,7 +257,7 @@ function to_store_sql(m::T; conflict_strategy = :error)::String where {T<:Abstra
 
   sql = if ! is_persisted(m) || (is_persisted(m) && conflict_strategy == :update)
     pos = findfirst(x -> x == primary_key_name(m), uf)
-    pos > 0 && splice!(uf, pos)
+    pos != nothing && splice!(uf, pos)
 
     fields = SQLColumn(uf)
     vals = join( map(x -> string(to_sqlinput(m, Symbol(x), getfield(m, Symbol(x)))), uf), ", ")

--- a/src/database_adapters/PostgreSQLDatabaseAdapter.jl
+++ b/src/database_adapters/PostgreSQLDatabaseAdapter.jl
@@ -1,6 +1,6 @@
 module PostgreSQLDatabaseAdapter
 
-using LibPQ, DataFrames, DataStreams, NamedTuples, Nullables
+using LibPQ, DataFrames, DataStreams, Nullables
 using SearchLight, SearchLight.Database, SearchLight.Loggers
 
 export DatabaseHandle, ResultHandle


### PR DESCRIPTION
I am using SearchLight.jl with Postgresql in julia 1.0
I noticed that PostgreSQLDatabaseAdapter is `using NamedTuples` which produces failures in the precompilation.  

findfirst now returns nothing instead o zero.