### PR TITLE
Fix Base.hash to use only the two-arg method

### DIFF
--- a/src/model_types.jl
+++ b/src/model_types.jl
@@ -54,12 +54,12 @@ DbId() = DbId(nothing)
 DbId(id::Number) = DbId(Int(id))
 DbId(id::AbstractString) = DbId(id)
 
-function hash(a::DbId)
-  Base.hash(a.value)
+function hash(a::DbId, h::UInt)
+  hash(a.value, h)
 end
 
 function ==(a::DbId, b::DbId)
-  hash(a) == hash(b)
+  a.value == b.value
 end
 
 Base.convert(::Type{DbId}, v::Union{Number,String}) = DbId(v)


### PR DESCRIPTION
Generated as part of an ecosystem-wide audit for one-arg hash methods.

`Base.hash` should only be extended via the two-arg method `hash(x, h::UInt)`.
Defining a one-arg `hash(x)` method, or giving the second argument a default
value, can lead to correctness bugs (hash contract violations when the seed
differs from the hard-coded default) and invalidation-related performance
issues. This is particularly necessary for Julia 1.13+ where the default hash
seed value will change.

This PR was generated with the assistance of generative AI.